### PR TITLE
Set posix_madvise(..., MADV_HUGEPAGE) for THP

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1870,6 +1870,11 @@ struct llama_mmap {
                         strerror(errno));
             }
         }
+        LLAMA_LOG_INFO("Setting posix_madvise(MADV_HUGEPAGE) in an attempt to enable THP for correct system configurations!\n");
+        if (posix_madvise(addr, file->size, MADV_HUGEPAGE)) {
+            LLAMA_LOG_WARN("warning: posix_madvise(.., MADV_HUGEPAGE) failed: %s\n",
+                    strerror(errno));
+        }
 
         // initialize list of mapped_fragments
         mapped_fragments.emplace_back(0, file->size);


### PR DESCRIPTION
## Summary
This is a simple test for my local 9950X + 96GB RAM + 24GB VRAM system to see if `posix_madvise(..., MADV_HUGEPAGE)` would effect inference speeds for the case where the DeepSeek R1 671B model is too big to fit into RAM+VRAM and must page off of disk cache with `kswapd0` reclaiming pages.

## tl;dr;
So setting `posix_madvise(..., MADV_HUGEPAGE)` does compile and run, it seems to *negatively* impact performance dropping token generation from about 3.5 tok/sec down below 2.0 tok/sec. Anecdotally looking at `btop` the PCIe Gen 5.0 Crucial T700 2TiB NVMe SSD pulls less i/o with this configured than without it.

So for now, *Explicit* Huge Pages seems more useful for AI inferencing than messing around further with *THP*s.

## Background
For reference,  Linux *Explicit* Huge Pages `libhugetlbfs` and `hugetlbfs` were added to Linux 2.5.46 development kernel in 2002.

A *different* system known as *Transparent* Huge Pages or (THP) was added more recently in Linux kernel since version 2.6.38 on 2011-03-14.

These two memory allocation mechanisms operate differently. Confusingly, they can bot be in operation on he same system.

* Explicit Huge Pages which are allocated explicitly by vm.nr_hugepages sysctl call
* Transparent Huge Pages which are allocated automatically by the kernel

The issue of larger page size tables is [still going on in the Linux Kernel discussions](https://lwn.net/Articles/974491/) today.

## Details
More confusingly, THPs seem more restricted in their use cases and given they are not *Explicit* may not actually be utilized.

The Kernel Config needs to be enabled to use THP including a [still experimental feature to enable read only file backed mmap sources](https://lkml.org/lkml/2019/6/24/1441).

```bash
## arch linux 6.13.1-arch1-1
$ zcat /proc/config.gz | grep CONFIG_READ_ONLY_THP_FOR_FS
CONFIG_READ_ONLY_THP_FOR_FS=y

## ubuntu 24.04 6.13.0-061300-generic
$ cat /boot/config-$(uname -r) | grep CONFIG_READ_ONLY_THP_FOR_FS
# CONFIG_READ_ONLY_THP_FOR_FS is not set

$ cat /sys/kernel/mm/transparent_hugepage/enabled
always [madvise] never # madvise is fine

# set defrag to always to stall on allocation and reclaim pages and compact memory first
$ echo always | sudo tee -a echo always /sys/kernel/mm/transparent_hugepage/defrag
$ cat /sys/kernel/mm/transparent_hugepage/defrag
[always] defer defer+madvise madvise never
```


## References
* [`MADV_HUGEPAGE`](https://www.man7.org/linux/man-pages/man2/madvise.2.html)
* [Transparent Huge Pages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html)

